### PR TITLE
Provides a standardized API

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ suitable constraints that can be passed onto a `getUserMedia` call.
 
 [![NPM](https://nodei.co/npm/rtc-screenshare.png)](https://nodei.co/npm/rtc-screenshare/)
 
-[![experimental](https://img.shields.io/badge/stability-experimental-red.svg)](https://github.com/dominictarr/stability#experimental) 
+[![experimental](https://img.shields.io/badge/stability-experimental-red.svg)](https://github.com/dominictarr/stability#experimental)
 
 ## Example Usage
 
@@ -41,7 +41,7 @@ function shareScreen() {
       target: document.getElementById('main')
     });
   });
-  
+
   // you better select something quick or this will be cancelled!!!
   setTimeout(screenshare.cancel, 5e3);
 }
@@ -69,7 +69,9 @@ screenshare.on('activate', function() {
 
 ```
 
-## Template Extension
+## Template Extensions
+
+### Chrome
 
 Template extension
 [source is available](https://github.com/rtc-io/rtc-screenshare-extension) and
@@ -78,6 +80,11 @@ an early, installable version of the extension is available in the
 
 __NOTE:__ The extension is not publicly available yet, but using the direct link
 you can install it.
+
+### Firefox
+
+Firefox allows screensharing without an extension, however, Mozilla only allows white
+listed domains to share the screen. You can apply for whitelists at https://bugzilla.mozilla.org/form.screen.share.whitelist - alternatively, you can use an [extension](https://github.com/muaz-khan/Firefox-Extensions/tree/master/enable-screen-capturing) to provide local whitelisting.
 
 ## Give it a Try
 

--- a/chrome.js
+++ b/chrome.js
@@ -1,12 +1,25 @@
+var detect = require('rtc-core/detect');
 var extend = require('cog/extend');
 var OPT_DEFAULTS = {
   target: 'rtc.io screenshare'
 };
 
-module.exports = function(opts) {
+/**
+  Returns true if we should use Chrome screensharing
+ **/
+exports.supported = function() {
+  return detect.browser === 'chrome';
+}
+
+/**
+  Creates the share context.
+ **/
+exports.share = function(opts) {
   var extension = require('chromex/client')(extend({}, OPT_DEFAULTS, opts, {
     target: (opts || {}).chromeExtension
   }));
+
+  extension.type = 'google/chrome';
 
   extension.available = function(callback) {
     return extension.satisfies((opts || {}).version, callback);
@@ -22,9 +35,9 @@ module.exports = function(opts) {
       if (! sourceId) {
         return callback(new Error('user rejected screen share request'));
       }
-      
+
       // pass the constraints through
-      return callback(null, {
+      return callback(null, extend({
         audio: false,
         video: {
           mandatory: {
@@ -35,13 +48,12 @@ module.exports = function(opts) {
             minFrameRate: 1,
             maxFrameRate: 5
           },
-
           optional: []
         }
-      });
+      }, opts.constraints));
     });
   };
-  
+
   extension.cancel = function() {
     extension.sendCommand('cancel', function(err) {
     });

--- a/examples/share-window.js
+++ b/examples/share-window.js
@@ -25,7 +25,7 @@ function shareScreen() {
       target: document.getElementById('main')
     });
   });
-  
+
   // you better select something quick or this will be cancelled!!!
   setTimeout(screenshare.cancel, 5e3);
 }
@@ -36,6 +36,11 @@ screenshare.available(function(err, version) {
   var actions = document.getElementById('actions');
 
   if (err) {
+    if (version === 'not-supported') {
+      return actions.appendChild(
+        h('div', 'Sorry, but screen capture is not supported in this browser and version [%s]', extension.type)
+      );
+    }
     return actions.appendChild(buttons.install);
   }
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-var detect = require('rtc-core/detect');
-
 /**
   # rtc-screenshare
 
@@ -29,4 +27,15 @@ var detect = require('rtc-core/detect');
   ([source](https://github.com/rtc-io/demo-screenshare)).
 
 **/
-module.exports = (detect.moz ? require('./moz') : require('./chrome'));
+module.exports = function() {
+  console.error('Screensharing is not supported on this device');
+};
+
+var handlers = [require('./chrome'), require('./moz')];
+for (var i = 0; i < handlers.length; i++) {
+  var handler = handlers[i];
+  if (handler && handler.supported()) {
+    module.exports = handler.share;
+    break;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "chromex": "^1.1.0",
     "cog": "^1.0.0",
+    "eventemitter3": "^1.1.1",
     "rtc-core": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes the plugin breaking in Firefox/other browsers due to Chrome specific things.

Each handler now is required to implement `supported` and `share` functions.

`supported` indicates whether the handler is appropriate for handling the current browser.
`share` returns a new share context. Once a share context is created, you can call `.request(callback)` to share the screen.