### PR TITLE
Lock chromex version until fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/rtc-io/rtc-screenshare",
   "dependencies": {
-    "chromex": "^1.1.0",
+    "chromex": "1.2.0",
     "cog": "^1.0.0",
     "eventemitter3": "^1.1.1",
     "rtc-core": "^4.0.0"


### PR DESCRIPTION
Chromex has broken with the latest `kgo` update (although a [fix](https://github.com/DamonOehlman/chromex/pull/2) is available).

In the meantime, lock the Chromex version to `1.2.0`