### PR TITLE
Sharing entire window with 'Share audio' checked is causing noises for Sender in a video call

### DIFF
--- a/chrome.js
+++ b/chrome.js
@@ -11,7 +11,6 @@ var CHROME_VERSION = getChromeVersion();
 // Chrome >= 50 allows for greater sharing options
 if (CHROME_VERSION >= 50) {
   REQUEST_OPTS.targets.push('tab');
-  REQUEST_OPTS.targets.push('audio');
 }
 
 /**
@@ -46,20 +45,9 @@ exports.share = function(opts) {
         return callback(new Error('user rejected screen share request'));
       }
 
-      var audioConstraints = false;
-      // Support audio on Chrome 50+
-      if (CHROME_VERSION >= 50) {
-        audioConstraints = {
-          mandatory: {
-            chromeMediaSource: 'desktop',
-            chromeMediaSourceId: sourceId
-          }
-        };
-      }
-
       // pass the constraints through
       return callback(null, extend({
-        audio: audioConstraints,
+        audio: false,
         video: {
           mandatory: {
             chromeMediaSource: 'desktop',


### PR DESCRIPTION
Hi @nathanoehlman,

I noticed, when I share my entire screen during a 2 way call, with the **Share audio** checkbox checked (which is checked by default), I start hearing severely distorted noise as I try to speak, even though I have no application on my machine playing any audio apart from video call application itself. Noises become  too loud, it makes hearing the other person in video call really hard. As soon I stop sharing, this noise goes away. 
![image](https://cloud.githubusercontent.com/assets/3058693/23247236/fce443ac-f9ec-11e6-8099-d17efb121032.png)

When sharing screen with 'Share audio' un-checked, this issue is not reproducible.

Have you seen this issue in your testing?

I did some research and found that use-case of sending audio along with **Entire screen** desktop capture is not really applicable to video calls (where sender of desktop stream is also listening to audio at the same time) according to Chrome team. More info here -  https://bugs.chromium.org/p/chromium/issues/detail?id=604043

I also found this 'Share audio' was enabled in `rtc-screenshare` recently ( PR https://github.com/rtc-io/rtc-screenshare/pull/19 )
Could you please consider removing 'audio' source request from `rtc-screenshare` (this PR) or make `rtc-screenshare` configurable for video call application to request screen sharing without requesting audio from `desktopCapture.chooseDesktopMedia` API

Thanks,
Raj
